### PR TITLE
Fixes 'unused_must_use' error on cargo build

### DIFF
--- a/src/request/dorequest.rs
+++ b/src/request/dorequest.rs
@@ -50,8 +50,8 @@ pub trait DoRequest: BaseRequest {
         let duration = Duration::from_secs(10);
         let url = try!(Url::parse(self.url()));
         let fresh_net = try!(request::Request::new(self.method(), url));
-        fresh_net.set_read_timeout(Some(duration));
-        fresh_net.set_write_timeout(Some(duration));
+        fresh_net.set_read_timeout(Some(duration)).unwrap();
+        fresh_net.set_write_timeout(Some(duration)).unwrap();
         let streaming_req = try!(fresh_net.start());
         let mut response = try!(streaming_req.send());
         let mut s = String::new();


### PR DESCRIPTION
Fixes the following error with `rustc 1.17.0`

```
warning: unused result which must be used
  --> src/request/dorequest.rs:53:9
   |
53 |         fresh_net.set_read_timeout(Some(duration));
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(unused_must_use)] on by default

warning: unused result which must be used
  --> src/request/dorequest.rs:54:9
   |
54 |         fresh_net.set_write_timeout(Some(duration));
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(unused_must_use)] on by default

    Finished dev [unoptimized + debuginfo] target(s) in 24.47 secs
```